### PR TITLE
added new option `escapeSequence`: optional custom escape sequence instead of default <notextile>  tag

### DIFF
--- a/lib/textile.js
+++ b/lib/textile.js
@@ -16,6 +16,12 @@
  *   - `wrapBlocks` **boolean**
  *     - `true` _default_ wraps basic blocks in paragraph tags.
  *     - `false` disables wrapping blocks in paragraph tags.
+ *   - `highlight` **function** `function (code) { return yourHighlighter(code); }`
+ *     - Allows highlighting of code if you wish using your own custom highlighting script.
+ *     - _default_ no highlighting.
+ *   - `escapeSequence` **string**
+ *     - Allows to set custom formatting escape sequence - textile formatting will be disabled for a string, contained between two such tokens.
+ *     - _default_ is `==`
  *
  * ## History
  *
@@ -44,14 +50,26 @@
     this.options.highlight = options && options.highlight !== undefined && typeof options.highlight === 'function' ? options.highlight : function (code) {
       return code;
     };
+    this.options.escapeSequence = options && options.escapeSequence !== undefined ? options.escapeSequence : '==';
     this.out = '';
     this.footnotes = [];
   }
 
   TextileConverter.prototype = {
+    regexpEscape: function (s) {
+      // escape special regexp symbols
+      return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+    },
+
     convert: function () {
       var i;
+      var escSeq = this.regexpEscape(this.options.escapeSequence);
+      var escapeSeqReplacer =  new RegExp(escSeq + "((?:.|\n)*?)" + escSeq, "g");
+
       this.src = this.src.replace(/^\n+/,'');
+
+      // set escaping for all that must be escaped
+      this.src = this.src.replace(escapeSeqReplacer, "$`<notextile>$1</notextile>$'");
 
       while (this.src.length) {
         for (i = 0; i < blockTypes.length; i++) {

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,9 @@ textile(source, { /* options */ });
   - `highlight` **function** `function (code) { return yourHighlighter(code); }`
     - Allows highlighting of code if you wish using your own custom highlighting script.
     - _default_ no highlighting.
+  - `escapeSequence` **string**
+    - Allows to set custom formatting escape sequence - textile formatting will be disabled for a string, contained between two such tokens.
+    - _default_ is `==`
 
 ## History
 

--- a/test/textile.html
+++ b/test/textile.html
@@ -96,7 +96,7 @@
 					equals( textile('p(myclass). My classy paragraph.'),'<p class="myclass">My classy paragraph.</p>','Classes and IDs are specified with parentheses.');
 					equals( textile('p(#myid). My ID paragraph.'),'<p id="myid">My ID paragraph.</p>');
 					equals( textile('p{color:red}. Red rum.'),'<p style="color:red;">Red rum.</p>','CSS styles are specified with braces.');
-					equals( textile('p[fr-fr]. En français.'),'<p lang="fr-fr">En français.</p>','Languages are specified with square brackets.');
+					equals( textile('p[fr-fr]. En franï¿½ais.'),'<p lang="fr-fr">En franï¿½ais.</p>','Languages are specified with square brackets.');
 					equals( textile('A *(myclass)classy* phrase.'),'<p>A <strong class="myclass">classy</strong> phrase.</p>','The same syntax may be applied to phrase modifiers');
 					equals( textile('The %{color:blue}blue% room.'),'<p>The <span style="color:blue;">blue</span> room.</p>');
 					equals( textile('p(myclass#myid3){color:green}[de-de]. A complex paragraph.'),'<p style="color:green;" class="myclass" id="myid3" lang="de-de">A complex paragraph.</p>','Block and phrase attributes may be combined.');
@@ -122,6 +122,9 @@
 					equals( textile('<pre>\nA HTML <b>example</b>.\n</pre>'),'<pre>\nA HTML &#60;b&#62;example&#60;/b&#62;.\n</pre>','The contents of explicit pre and code tags are escaped for display.');
 					equals( textile('<code>\nAnother HTML <b>example</b>.\n</code>'),'<p><code>\nAnother HTML &#60;b&#62;example&#60;/b&#62;.\n</code></p>');
 					equals( textile('<notextile>\np. Leave me alone\n</notextile>'),'<p>\np. Leave me alone\n</p>');
+					equals( textile('==\np. Leave me alone\n=='),'<p>\np. Leave me alone\n</p>');
+					equals( textile('$\np. Leave me alone\n$', {escapeSequence: '$'}),'<p>\np. Leave me alone\n</p>');
+					equals( textile('|||\np. Leave me alone\n|||', {escapeSequence: '|||'}),'<p>\np. Leave me alone\n</p>');
 				});
 
 				test("Alignment",function() {


### PR DESCRIPTION
defaults to `==` from http://txstyle.org/doc/6/no-textile-processing
